### PR TITLE
Package name fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "nrm/simplyrets-client",
+    "name": "nrm/simply-rets-client",
     "description": "Simply RETS PHP client built with Guzzle",
     "keywords": ["rets", "simplyrets", "real estate"],
     "type": "library",


### PR DESCRIPTION
Documentation says `nrm/simply-rets-client` but the composer package is registered as `nrm/simplyrets-client`
